### PR TITLE
Combine configs into single pyproject.toml

### DIFF
--- a/2024/python/.env
+++ b/2024/python/.env
@@ -1,1 +1,0 @@
-PYTHONPATH=src

--- a/2024/python/pylintrc
+++ b/2024/python/pylintrc
@@ -1,8 +1,0 @@
-[MASTER]
-init-hook='import sys; sys.path.insert(0, "./src")'
-
-[MESSAGES CONTROL]
-disable=
-    C0114,
-    C0115,
-    C0116

--- a/2024/python/pyproject.toml
+++ b/2024/python/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.pyright]
+include = ["src", "tests"]
+extraPaths = ["src"]
+typeCheckingMode = "strict"
+
+[tool.pylint.MAIN]
+init-hook = "import sys; sys.path.append('src')"
+disable = [
+  "missing-module-docstring",
+  "missing-class-docstring",
+  "missing-function-docstring",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/2024/python/pyrightconfig.json
+++ b/2024/python/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "typeCheckingMode": "strict"
+}

--- a/2024/python/pyrightconfig.json
+++ b/2024/python/pyrightconfig.json
@@ -1,3 +1,0 @@
-{
-  "typeCheckingMode": "strict"
-}

--- a/2024/python/pytest.ini
+++ b/2024/python/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-pythonpath = src


### PR DESCRIPTION
This replaces:
  - pyrightconfig.json
  - pylintrc
  - pytest.ini

All needed settings are moved into one pyproject.toml file.